### PR TITLE
speed up for neon intrinsics impl

### DIFF
--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -41,16 +41,56 @@ int dotProductNeon(short* vector1, short* vector2, short len) {
 
     // 4-element vector of zeros
     int32x4_t partialSumsNeon = vdupq_n_s32(0);
+    int32x4_t sum1 = vdupq_n_s32(0);
+    int32x4_t sum2 = vdupq_n_s32(0);
+    int32x4_t sum3 = vdupq_n_s32(0);
+    int32x4_t sum4 = vdupq_n_s32(0);
 
-    // Main loop (note that loop index goes through segments)
-    for(short i = 0; i < segments; i++) {
+    // Main loop (note that loop index goes through segments). Unroll with 4
+    int i = 0;
+    for(; i+3 < segments; i+=4) {
+        // sometimes we may do preload, but on my MI8 it decrease speed.. sad
+        //asm volatile("prfm pldl1keep, [%0, #256]" : :"r"(vector1) :);
+        //asm volatile("prfm pldl1keep, [%0, #256]" : :"r"(vector2) :);
+
         // Load vector elements to registers
-        short offset = i * transferSize;
-        int16x4_t vector1Neon = vld1_s16(vector1 + offset);
-        int16x4_t vector2Neon = vld1_s16(vector2 + offset);
+        int16x8_t v11 = vld1q_s16(vector1);
+        int16x4_t v11_low = vget_low_s16(v11);
+        int16x4_t v11_high = vget_high_s16(v11);
+
+        int16x8_t v12 = vld1q_s16(vector2);
+        int16x4_t v12_low = vget_low_s16(v12);
+        int16x4_t v12_high = vget_high_s16(v12);
+
+        int16x8_t v21 = vld1q_s16(vector1+8);
+        int16x4_t v21_low = vget_low_s16(v21);
+        int16x4_t v21_high = vget_high_s16(v21);
+
+        int16x8_t v22 = vld1q_s16(vector2+8);
+        int16x4_t v22_low = vget_low_s16(v22);
+        int16x4_t v22_high = vget_high_s16(v22);
 
         // Multiply and accumulate: partialSumsNeon += vector1Neon * vector2Neon
+        sum1 = vmlal_s16(sum1, v11_low, v12_low);
+        sum2 = vmlal_s16(sum2, v11_high, v12_high);
+        sum3 = vmlal_s16(sum3, v21_low, v22_low);
+        sum4 = vmlal_s16(sum4, v21_high, v22_high);
+
+        vector1 += 16;
+        vector2 += 16;
+    }
+    partialSumsNeon = sum1 + sum2 + sum3 + sum4;
+
+	// Sum up remain parts
+    int remain = len % transferSize;
+    for(i=0; i<remain; i++) {
+
+        int16x4_t vector1Neon = vld1_s16(vector1);
+        int16x4_t vector2Neon = vld1_s16(vector2);
         partialSumsNeon = vmlal_s16(partialSumsNeon, vector1Neon, vector2Neon);
+
+        vector1 += 4;
+        vector2 += 4;
     }
 
     // Store partial sums
@@ -59,7 +99,7 @@ int dotProductNeon(short* vector1, short* vector2, short len) {
 
     // Sum up partial sums
     int result = 0;
-    for(short i = 0; i < transferSize; i++) {
+    for(int i = 0; i < transferSize; i++) {
         result += partialSums[i];
     }
 

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -49,9 +49,9 @@ int dotProductNeon(short* vector1, short* vector2, short len) {
     // Main loop (note that loop index goes through segments). Unroll with 4
     int i = 0;
     for(; i+3 < segments; i+=4) {
-        // sometimes we may do preload, but on my MI8 it decrease speed.. sad
-        //asm volatile("prfm pldl1keep, [%0, #256]" : :"r"(vector1) :);
-        //asm volatile("prfm pldl1keep, [%0, #256]" : :"r"(vector2) :);
+        // Preload may help speed up sometimes
+        // asm volatile("prfm pldl1keep, [%0, #256]" : :"r"(vector1) :);
+        // asm volatile("prfm pldl1keep, [%0, #256]" : :"r"(vector2) :);
 
         // Load vector elements to registers
         int16x8_t v11 = vld1q_s16(vector1);


### PR DESCRIPTION
Tested on my MI8 phone (SoC is QC845)

The previous implemention:
non-neon: 6ms
noen: 8ms

Updated implementation:
non-neon: 6ms
neon: 4ms~6ms (not very stable, but faster than previous)

Also fix the missing sum of remain (tail) part of array.